### PR TITLE
Add travis.ci build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+services:
+  - docker
+
+language: python
+
+python:
+  - "2.7"
+  - "3.5"
+
+before_install:
+  - pip --version
+  - pip install -r requirements.txt
+  - docker --version
+  - docker-compose --version
+
+install:
+  - pip install -r requirements.txt
+
+before_script:
+  - docker-compose -f test/compose/sdc.yml pull
+
+script:
+  - cd test; python -m pytest
+
+after_script:
+
+after_success:


### PR DESCRIPTION
Adding [travis.ci](travis.ci) build

@brockn you should have recieved a request a day or two ago to enable travis.ci for the phdata github group, can you take a look at that? After it's enabled the build should automatically start working.